### PR TITLE
Support for REPEAT (On GNU Awk)

### DIFF
--- a/logo.awk
+++ b/logo.awk
@@ -6,6 +6,7 @@ BEGIN {
 	pi = atan2(0, -1)
 	res = 10
 	N = 0
+	r = 0
 
 	print "<?xml version='1.0' encoding='UTF-8' standalone='no'?>"
 	print ""
@@ -64,20 +65,23 @@ function home() {
 function repeat(n) {
 	N = n
 	cmds = ""
+	r = 1 
 }
 
 function endrepeat() {
-	l = split(cmds, cmdarray, "\n")
+	cmd_len = split(cmds, cmdarray, "\n")
 	for (i = 1; i<=N; i++) {
-		for (j = 1; j<=l; j++) {
+		for (j = 1; j<=cmd_len; j++) {
 			act(cmdarray[j], 0);
 		}
 	}
 	N = 0
+	cmds = ""
+	r = 0
 }
 
 function act(input, repeating) {
-split(input, parse)
+l=split(input, parse)
 switch (input) {
 	case /^FD/:
 		(!repeating) ? move(+parse[2]) : cmds = cmds "\n" $0
@@ -100,14 +104,14 @@ switch (input) {
 	case /^HOME/:
 		(!repeating) ? home() : cmds = cmds "\n" $0
 		break
-	case /^\]/:
-		endrepeat()
-		break
 	case /^REPEAT\W+[0-9]*\W*\[/:
 		repeat(+$2)
+		break
+	case /^\]/:
+		endrepeat()
 		break
 }
 }
 
-{ act($0, 1) }
+{ act($0, r) }
 

--- a/logo.awk
+++ b/logo.awk
@@ -5,6 +5,7 @@
 BEGIN {
 	pi = atan2(0, -1)
 	res = 10
+	N = 0
 
 	print "<?xml version='1.0' encoding='UTF-8' standalone='no'?>"
 	print ""
@@ -66,45 +67,47 @@ function repeat(n) {
 }
 
 function endrepeat() {
-	l = split(cmds, cmds, "\n")
+	l = split(cmds, cmdarray, "\n")
 	for (i = 1; i<=N; i++) {
 		for (j = 1; j<=l; j++) {
-			act(cmds[j]);
+			act(cmdarray[j], 0);
 		}
 	}
 	N = 0
 }
 
-function act(input) {
+function act(input, repeating) {
+split(input, parse)
 switch (input) {
-/^FD/:
-	(N == 0) ? move(+$2) : cmds = cmds "\n" $0
-	break
-/^BK/:
-	move(-$2)
-	break
-/^RT/:
-	turn(+$2)
-	break
-/^LT/:
-	turn(-$2)
-/^PU/:
-	penup()
-	break
-/^PD/:
-	 pendown()
-	break
-/^HOME/:
-	home()
-	break
-/^\]/:
-	endrepeat()
-	break
-/^REPEAT/:
-	repeat(+$2)
-	break
+	case /^FD/:
+		(!repeating) ? move(+parse[2]) : cmds = cmds "\n" $0
+		break
+	case /^BK/:
+		(!repeating) ? move(-parse[2]) : cmds = cmds "\n" $0
+		break
+	case /^RT/:
+		(!repeating) ? turn(+parse[2]) : cmds = cmds "\n" $0
+		break
+	case /^LT/:
+		(!repeating) ? turn(-parse[2]) : cmds = cmds "\n" $0
+		break
+	case /^PU/:
+		(!repeating) ? penup() : cmds = cmds "\n" $0
+		break
+	case /^PD/:
+		 pen(!repeating) ? down() : cmds = cmds "\n" $0
+		break
+	case /^HOME/:
+		(!repeating) ? home() : cmds = cmds "\n" $0
+		break
+	case /^\]/:
+		endrepeat()
+		break
+	case /^REPEAT\W+[0-9]*\W*\[/:
+		repeat(+$2)
+		break
 }
 }
 
-{ act() }
+{ act($0, 1) }
 

--- a/logo.awk
+++ b/logo.awk
@@ -69,13 +69,15 @@ function repeat(n) {
 }
 
 function endrepeat(depth) {
+	# Seemingly this idiom with tmp and then writing into cmdarray is required
+	# and you can't split into a multidimensional array
 	cmd_len[depth] = split(cmds[depth], tmp, "\n")
 	for (key in tmp) {
 		cmdarray[depth,key] = tmp[key]
 	}
-	for (i[depth] = 1; i[depth]<=(+cmdarray[depth, 1]); i[depth]++) {
-		for (j[depth] = 1; j[depth]<=cmd_len[depth]; j[depth]++) {
-			act(cmdarray[depth,j[depth]], depth-1);
+	for (i = 1; i<=(+cmdarray[depth, 1]); i++) {
+		for (j = 1; j<=cmd_len[depth]; j++) {
+			act(cmdarray[depth,j], depth-1);
 		}
 	}
 	d-=1
@@ -87,10 +89,7 @@ function act(input, depth) {
 			case /^\]/:
 				endrepeat(depth)
 				break
-			case /^REPEAT\W+[0-9]*\W*\[/:
-					repeat(+$2)
-					break
-			default:
+						default:
 				cmds[depth] = cmds[depth] "\n" input
 		}
 		return
@@ -119,11 +118,9 @@ function act(input, depth) {
 		case /^HOME/:
 			home()
 			break
-		case /^REPEAT\W+[0-9]*\W*\[/:
-				repeat(+$2)
-				break
 	}
 }
 
+/^REPEAT\W+[0-9]*\W*\[/ { repeat(+$2) }
 { act($0, d) }
 

--- a/logo.awk
+++ b/logo.awk
@@ -60,11 +60,51 @@ function home() {
 	angle = -90
 }
 
-/^FD/   { move(+$2); }
-/^BK/   { move(-$2); }
-/^RT/   { turn(+$2); }
-/^LT/   { turn(-$2); }
-/^PU/   { penup();   }
-/^PD/   { pendown(); }
-/^HOME/ { home();    }
+function repeat(n) {
+	N = n
+	cmds = ""
+}
+
+function endrepeat() {
+	l = split(cmds, cmds, "\n")
+	for (i = 1; i<=N; i++) {
+		for (j = 1; j<=l; j++) {
+			act(cmds[j]);
+		}
+	}
+	N = 0
+}
+
+function act(input) {
+switch (input) {
+/^FD/:
+	(N == 0) ? move(+$2) : cmds = cmds "\n" $0
+	break
+/^BK/:
+	move(-$2)
+	break
+/^RT/:
+	turn(+$2)
+	break
+/^LT/:
+	turn(-$2)
+/^PU/:
+	penup()
+	break
+/^PD/:
+	 pendown()
+	break
+/^HOME/:
+	home()
+	break
+/^\]/:
+	endrepeat()
+	break
+/^REPEAT/:
+	repeat(+$2)
+	break
+}
+}
+
+{ act() }
 

--- a/logo.awk
+++ b/logo.awk
@@ -85,13 +85,10 @@ function endrepeat(depth) {
 
 function act(input, depth) {
 	if (depth) {
-		switch (input) {
-			case /^\]/:
-				endrepeat(depth)
-				break
-						default:
-				cmds[depth] = cmds[depth] "\n" input
-		}
+		if (input ~ /^\]/):
+			endrepeat(depth)
+		else
+			cmds[depth] = cmds[depth] "\n" input
 		return
 	}
 

--- a/logo.awk
+++ b/logo.awk
@@ -81,35 +81,43 @@ function endrepeat() {
 }
 
 function act(input, repeating) {
+if (repeating) {
+	switch (input) {
+		case /^\]/:
+			endrepeat()
+			break
+		default:
+			cmds = cmds "\n" $0
+	}
+}
+else {
 l=split(input, parse)
 switch (input) {
 	case /^FD/:
-		(!repeating) ? move(+parse[2]) : cmds = cmds "\n" $0
+		move(+parse[2])
 		break
 	case /^BK/:
-		(!repeating) ? move(-parse[2]) : cmds = cmds "\n" $0
+		move(-parse[2])
 		break
 	case /^RT/:
-		(!repeating) ? turn(+parse[2]) : cmds = cmds "\n" $0
+		turn(+parse[2])
 		break
 	case /^LT/:
-		(!repeating) ? turn(-parse[2]) : cmds = cmds "\n" $0
+		turn(-parse[2])
 		break
 	case /^PU/:
-		(!repeating) ? penup() : cmds = cmds "\n" $0
+		penup()
 		break
 	case /^PD/:
-		 pen(!repeating) ? down() : cmds = cmds "\n" $0
+		down()
 		break
 	case /^HOME/:
-		(!repeating) ? home() : cmds = cmds "\n" $0
+		home()
 		break
 	case /^REPEAT\W+[0-9]*\W*\[/:
-		repeat(+$2)
-		break
-	case /^\]/:
-		endrepeat()
-		break
+			repeat(+$2)
+			break
+}
 }
 }
 

--- a/logo.awk
+++ b/logo.awk
@@ -6,7 +6,8 @@ BEGIN {
 	pi = atan2(0, -1)
 	res = 10
 	N = 0
-	r = 0
+	d = 0
+	split("", cmdarray)
 
 	print "<?xml version='1.0' encoding='UTF-8' standalone='no'?>"
 	print ""
@@ -63,63 +64,66 @@ function home() {
 }
 
 function repeat(n) {
-	N = n
-	cmds = ""
-	r = 1 
+	d += 1
+	cmds[d] = n
 }
 
-function endrepeat() {
-	cmd_len = split(cmds, cmdarray, "\n")
-	for (i = 1; i<=N; i++) {
-		for (j = 1; j<=cmd_len; j++) {
-			act(cmdarray[j], 0);
+function endrepeat(depth) {
+	cmd_len[depth] = split(cmds[depth], tmp, "\n")
+	for (key in tmp) {
+		cmdarray[depth,key] = tmp[key]
+	}
+	for (i[depth] = 1; i[depth]<=(+cmdarray[depth, 1]); i[depth]++) {
+		for (j[depth] = 1; j[depth]<=cmd_len[depth]; j[depth]++) {
+			act(cmdarray[depth,j[depth]], depth-1);
 		}
 	}
-	N = 0
-	cmds = ""
-	r = 0
+	d-=1
 }
 
-function act(input, repeating) {
-if (repeating) {
+function act(input, depth) {
+	if (depth) {
+		switch (input) {
+			case /^\]/:
+				endrepeat(depth)
+				break
+			case /^REPEAT\W+[0-9]*\W*\[/:
+					repeat(+$2)
+					break
+			default:
+				cmds[depth] = cmds[depth] "\n" input
+		}
+		return
+	}
+
+	l=split(input, parse)
 	switch (input) {
-		case /^\]/:
-			endrepeat()
+		case /^FD/:
+			move(+parse[2])
 			break
-		default:
-			cmds = cmds "\n" $0
+		case /^BK/:
+			move(-parse[2])
+			break
+		case /^RT/:
+			turn(+parse[2])
+			break
+		case /^LT/:
+			turn(-parse[2])
+			break
+		case /^PU/:
+			penup()
+			break
+		case /^PD/:
+			down()
+			break
+		case /^HOME/:
+			home()
+			break
+		case /^REPEAT\W+[0-9]*\W*\[/:
+				repeat(+$2)
+				break
 	}
 }
-else {
-l=split(input, parse)
-switch (input) {
-	case /^FD/:
-		move(+parse[2])
-		break
-	case /^BK/:
-		move(-parse[2])
-		break
-	case /^RT/:
-		turn(+parse[2])
-		break
-	case /^LT/:
-		turn(-parse[2])
-		break
-	case /^PU/:
-		penup()
-		break
-	case /^PD/:
-		down()
-		break
-	case /^HOME/:
-		home()
-		break
-	case /^REPEAT\W+[0-9]*\W*\[/:
-			repeat(+$2)
-			break
-}
-}
-}
 
-{ act($0, r) }
+{ act($0, d) }
 


### PR DESCRIPTION
Assuming the project uses GNU Awk (This could be ported to another Awk dialect easily but annoyingly by replacing the switch with an if-else tower if needed):

This should be* a functional implementation of the REPEAT command. i.e a message chain of

> REPEAT 5 [
> FD 5
> RT 72
> ]

will produce a pentagon.

I considered allowing the "]" to fall on a line with another command but I don't think it works with the format of the bot, and is also about as much complexity to parse well as the entire feature so probably not worth it.

It's somewhat ugly in implementation and I don't think there's consensus  on exactly how the feature should work anyway so not sure if it entirely makes sense to merge

* I tested this very informally but it appears to be fine